### PR TITLE
Fix moderation tags and history length

### DIFF
--- a/history.go
+++ b/history.go
@@ -47,8 +47,11 @@ func (h *History) GetAsString(place string) string {
 			ret += fmt.Sprintf("\n%s", m.Content)
 		}
 	}
-	// @todo cut so it won't be longer than maxLength
-	return strings.TrimSpace(ret)
+	ret = strings.TrimSpace(ret)
+	if h.MaxLength > 0 && len(ret) > h.MaxLength {
+		ret = ret[len(ret)-h.MaxLength:]
+	}
+	return ret
 }
 
 func (h *History) AsOpenAIMessages(place string) []openai.Message {

--- a/openai/moderation.go
+++ b/openai/moderation.go
@@ -21,7 +21,7 @@ type Result struct {
 		HarassmentThreatening bool `json:"harassment/threatening"`
 		SelfHarm              bool `json:"self-harm"`
 		SelfHarmIntent        bool `json:"self-harm/intent"`
-		SelfHarmInstructions  bool `json:"self-harm/intstructions"`
+		SelfHarmInstructions  bool `json:"self-harm/instructions"`
 		Sexual                bool `json:"sexual"`
 		SexualMinors          bool `json:"sexual/minors"`
 		Violence              bool `json:"violence"`
@@ -34,7 +34,7 @@ type Result struct {
 		HarassmentThreatening float64 `json:"harassment/threatening"`
 		SelfHarm              float64 `json:"self-harm"`
 		SelfHarmIntent        float64 `json:"self-harm/intent"`
-		SelfHarmInstructions  float64 `json:"self-harm/intstructions"`
+		SelfHarmInstructions  float64 `json:"self-harm/instructions"`
 		Sexual                float64 `json:"sexual"`
 		SexualMinors          float64 `json:"sexual/minors"`
 		Violence              float64 `json:"violence"`

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -212,15 +212,15 @@ func (o *OpenAI) requestAPI(method, url string, request interface{}, oaResponse 
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.ApiToken))
 	req.Header.Set("OpenAI-Beta", "assistants=v2")
-	client := &http.Client{}
+	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("cannot perform request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("received non-200 response: %d", resp.StatusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("received non-2xx response: %d", resp.StatusCode)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(oaResponse)


### PR DESCRIPTION
## Summary
- fix typo in OpenAI moderation response tags
- enforce maximum history length when returning message history
- make OpenAI API client handle non-2xx codes and set HTTP timeout

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68429d6d363c83238ff571c69551202c